### PR TITLE
Add API helper for retrieving user problem data

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Clinton Blackburn <cblackburn@edx.org>
 Dennis Jen <djen@edx.org>
 Gabe Mulley <gabe@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
+Tim Krones <t.krones@gmx.net>

--- a/analyticsclient/client.py
+++ b/analyticsclient/client.py
@@ -8,6 +8,7 @@ from analyticsclient.course import Course
 from analyticsclient.exceptions import ClientError, InvalidRequestError, NotFoundError, TimeoutError
 from analyticsclient.module import Module
 from analyticsclient.status import Status
+from analyticsclient.users import UserProblemWeeklyData
 
 
 log = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ class Client(object):
 
         self.status = Status(self)
         self.courses = lambda course_id: Course(self, course_id)
+        self.user_problem_weekly_data = lambda course_id, user_id: UserProblemWeeklyData(self, course_id, user_id)
         self.modules = lambda course_id, module_id: Module(self, course_id, module_id)
 
     def get(self, resource, timeout=None, data_format=DF.JSON):

--- a/analyticsclient/tests/test_users.py
+++ b/analyticsclient/tests/test_users.py
@@ -1,0 +1,60 @@
+import json
+
+import httpretty
+
+from analyticsclient.exceptions import NotFoundError
+from analyticsclient.tests import ClientTestCase
+
+
+class UserWeeklyProblemDataTests(ClientTestCase):
+    def setUp(self):
+        super(UserWeeklyProblemDataTests, self).setUp()
+        self.course_id = 'edX/DemoX/Demo_Course'
+        self.course = self.client.courses(self.course_id)
+        self.user_id = 10000
+        httpretty.enable()
+
+    def tearDown(self):
+        super(UserWeeklyProblemDataTests, self).tearDown()
+        httpretty.disable()
+
+    def test_not_found(self):
+        """ User API calls should raise a NotFoundError when provided with an invalid user ID. """
+
+        user_id = 555
+        uri = self.get_api_url('courses/{}/users/{}/problem_data/'.format(self.course_id, user_id))
+        httpretty.register_uri(httpretty.GET, uri, status=404)
+
+        problem_data_client = self.client.user_problem_weekly_data(self.course_id, user_id)
+        with self.assertRaises(NotFoundError):
+            problem_data_client.weekly_problem_data()
+
+    def test_weekly_problem_data(self):
+        body = [
+            {
+                "id": 1,
+                "week_ending": "2015-08-20",
+                "course_id": self.course_id,
+                "user_id": self.user_id,
+                "problem_id": "dummy_problem_1",
+                "num_attempts": 11,
+                "most_recent_score": 0,
+                "max_score": 3,
+            },
+            {
+                "id": 2,
+                "week_ending": "2015-08-27",
+                "course_id": self.course_id,
+                "user_id": self.user_id,
+                "problem_id": "dummy_problem_2",
+                "num_attempts": 22,
+                "most_recent_score": 1,
+                "max_score": 3,
+            },
+        ]
+
+        uri = self.get_api_url('courses/{}/users/{}/problem_data/'.format(self.course_id, self.user_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(
+            body, self.client.user_problem_weekly_data(self.course_id, self.user_id).weekly_problem_data()
+        )

--- a/analyticsclient/users.py
+++ b/analyticsclient/users.py
@@ -1,0 +1,29 @@
+import analyticsclient.constants.data_format as DF
+
+
+class UserProblemWeeklyData(object):
+    """ Get user problem history per week. """
+
+    def __init__(self, client, course_id, user_id):
+        """
+        Initialize the API client.
+
+        Arguments:
+
+            client (analyticsclient.client.Client): The client to use to access remote resources.
+            user_id (int): The ID of the user
+
+        """
+        self.client = client
+        self.course_id = course_id
+        self.user_id = user_id
+
+    def weekly_problem_data(self, data_format=DF.JSON):
+        """
+        Get weekly reports about problem history of a user.
+
+        Arguments:
+            data_format (str): Format in which data should be returned
+        """
+        path = 'courses/{}/users/{}/problem_data/'.format(self.course_id, self.user_id)
+        return self.client.get(path, data_format=data_format)


### PR DESCRIPTION
This PR changes the analytics API client so that it can use the new API added in https://github.com/edx/edx-analytics-data-api/pull/81.

**Dependencies**

- https://github.com/edx/edx-analytics-pipeline/pull/147
- https://github.com/edx/edx-analytics-data-api/pull/81

**Partner Information**

Third-party open edX instance, not an edX partner.
