### PR TITLE
New API endpoint for retrieving typology data

### DIFF
--- a/analyticsclient/constants/typology.py
+++ b/analyticsclient/constants/typology.py
@@ -1,0 +1,8 @@
+"""
+Constants used in the typology report.
+
+Typology categorizes users' interaction with videos and problems in each section of the course.
+"""
+NONE = 0
+SOME = 1
+ALL = 2

--- a/analyticsclient/course.py
+++ b/analyticsclient/course.py
@@ -105,6 +105,16 @@ class Course(object):
         path = 'courses/{0}/problems/'.format(self.course_id)
         return self.client.get(path, data_format=data_format)
 
+    def typology(self, data_format=DF.JSON):
+        """
+        Get the typology data for the course.
+
+        Arguments:
+            data_format (str): Format in which data should be returned
+        """
+        path = 'courses/{0}/typology/'.format(self.course_id)
+        return self.client.get(path, data_format=data_format)
+
     def videos(self, data_format=DF.JSON):
         """
         Get the videos for the course.

--- a/analyticsclient/tests/test_course.py
+++ b/analyticsclient/tests/test_course.py
@@ -6,6 +6,7 @@ import httpretty
 from analyticsclient.constants import activity_type as at
 from analyticsclient.constants import data_format
 from analyticsclient.constants import demographic as demo
+from analyticsclient.constants import typology
 from analyticsclient.exceptions import NotFoundError, InvalidRequestError
 from analyticsclient.tests import ClientTestCase
 
@@ -147,6 +148,23 @@ class CoursesTests(ClientTestCase):
         uri = self.get_api_url('courses/{0}/problems/'.format(self.course_id))
         httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
         self.assertEqual(body, self.course.problems())
+
+    @httpretty.activate
+    def test_typology(self):
+
+        body = [
+            {
+                "chapter_id": "week2",
+                "video_type": typology.ALL,
+                "problem_type": typology.SOME,
+                "num_users": 1,
+                "created": "2015-08-20T043618"
+            }
+        ]
+
+        uri = self.get_api_url('courses/{0}/typology/'.format(self.course_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.course.typology())
 
     @httpretty.activate
     def test_videos(self):


### PR DESCRIPTION
**Description**
PR 3 of 4 to implement Student Typology / Trajectory.

This provides access to the new analytics API added in https://github.com/edx/edx-analytics-data-api/pull/83 , and defines some constants used to understand the data values.

**Dependencies**:
- https://github.com/edx/edx-analytics-pipeline/pull/142
- https://github.com/edx/edx-analytics-data-api/pull/83

**Partner information**: not an edX partner - 3rd party-hosted open edX instance

**Reviewers**: @itsjeyd and TBD
