### PR TITLE
Support new server API endpoint to get tags distribution in the client library

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Clinton Blackburn <cblackburn@edx.org>
 Dennis Jen <djen@edx.org>
 Gabe Mulley <gabe@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
+Dmitry Viskov <dmitry.viskov@webenterprise.ru>

--- a/analyticsclient/course.py
+++ b/analyticsclient/course.py
@@ -105,6 +105,16 @@ class Course(object):
         path = 'courses/{0}/problems/'.format(self.course_id)
         return self.client.get(path, data_format=data_format)
 
+    def problems_and_tags(self, data_format=DF.JSON):
+        """
+        Get the problems for the course with assigned tags.
+
+        Arguments:
+            data_format (str): Format in which data should be returned
+        """
+        path = 'courses/{0}/problems_and_tags/'.format(self.course_id)
+        return self.client.get(path, data_format=data_format)
+
     def videos(self, data_format=DF.JSON):
         """
         Get the videos for the course.

--- a/analyticsclient/tests/test_course.py
+++ b/analyticsclient/tests/test_course.py
@@ -149,6 +149,19 @@ class CoursesTests(ClientTestCase):
         self.assertEqual(body, self.course.problems())
 
     @httpretty.activate
+    def test_problems_and_tags(self):
+
+        body = [
+            {
+                'module_id': 'i4x://a/b/c'
+            }
+        ]
+
+        uri = self.get_api_url('courses/{0}/problems_and_tags/'.format(self.course_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.course.problems_and_tags())
+
+    @httpretty.activate
     def test_videos(self):
 
         body = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='edx-analytics-data-api-client',
-    version='0.6.1',
+    version='0.7.0',
     packages=['analyticsclient', 'analyticsclient.constants'],
     url='https://github.com/edx/edx-analytics-data-api-client',
     description='Client used to access edX analytics data warehouse',


### PR DESCRIPTION
This PR is related to this one https://github.com/edx/edx-analytics-pipeline/pull/247 and this one https://github.com/edx/edx-analytics-data-api/pull/115 . The updated API client will be used in the Analytics Dashboard to retrieve information about tags distribution.

@mulby could you please take a look.