### PR TITLE
Add credit enrollment mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ Dennis Jen <djen@edx.org>
 Gabe Mulley <gabe@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
+Tyler Hallada <thallada@edx.org>

--- a/analyticsclient/constants/enrollment_modes.py
+++ b/analyticsclient/constants/enrollment_modes.py
@@ -1,6 +1,7 @@
 AUDIT = u'audit'
+CREDIT = u'credit'
 HONOR = u'honor'
 PROFESSIONAL = u'professional'
 VERIFIED = u'verified'
 
-ALL = [AUDIT, HONOR, PROFESSIONAL, VERIFIED]
+ALL = [AUDIT, CREDIT, HONOR, PROFESSIONAL, VERIFIED]

--- a/analyticsclient/tests/test_helpers.py
+++ b/analyticsclient/tests/test_helpers.py
@@ -37,6 +37,7 @@ class HelperTests(TestCase):
 
     def test_enrollment_modes(self):
         self.assertEqual('audit', enrollment_modes.AUDIT)
+        self.assertEqual('credit', enrollment_modes.CREDIT)
         self.assertEqual('honor', enrollment_modes.HONOR)
         self.assertEqual('professional', enrollment_modes.PROFESSIONAL)
         self.assertEqual('verified', enrollment_modes.VERIFIED)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='edx-analytics-data-api-client',
-    version='0.7.0',
+    version='0.8.0',
     packages=['analyticsclient', 'analyticsclient.constants'],
     url='https://github.com/edx/edx-analytics-data-api-client',
     description='Client used to access edX analytics data warehouse',


### PR DESCRIPTION
The "credit" track is being [added to the API](https://github.com/edx/edx-analytics-data-api/pull/125). This change updates the client to let it know it exists.

@dsjen @ajpal 