### PR TITLE
Add API method for retrieving status and URL of CSV reports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@ Gabe Mulley <gabe@edx.org>
 Dylan Rhodes <dylanr@stanford.edu>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
 Tyler Hallada <thallada@edx.org>
+Braden MacDonald <braden@opencraft.com>

--- a/analyticsclient/course.py
+++ b/analyticsclient/course.py
@@ -115,6 +115,16 @@ class Course(object):
         path = 'courses/{0}/problems_and_tags/'.format(self.course_id)
         return self.client.get(path, data_format=data_format)
 
+    def reports(self, report_name, data_format=DF.JSON):
+        """
+        Get CSV download information for a particular report in the course.
+
+        Arguments:
+            report_name (str): Report name, e.g. "problem_response"
+        """
+        path = 'courses/{0}/reports/{1}/'.format(self.course_id, report_name)
+        return self.client.get(path, data_format=data_format)
+
     def videos(self, data_format=DF.JSON):
         """
         Get the videos for the course.

--- a/analyticsclient/tests/test_course.py
+++ b/analyticsclient/tests/test_course.py
@@ -162,6 +162,22 @@ class CoursesTests(ClientTestCase):
         self.assertEqual(body, self.course.problems_and_tags())
 
     @httpretty.activate
+    def test_reports(self):
+
+        body = {
+            "last_modified": "2016-08-12T043411",
+            "file_size": 3419,
+            "course_id": "Example_Demo_2016-08",
+            "expiration_date": "2016-08-12T233704",
+            "download_url": "https://bucket.s3.amazonaws.com/foo_bar_1_problem_response.csv?Signature=123&Expires=456",
+            "report_name": "problem_response"
+        }
+
+        uri = self.get_api_url('courses/{0}/reports/problem_response/'.format(self.course_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.course.reports("problem_response"))
+
+    @httpretty.activate
     def test_videos(self):
 
         body = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='edx-analytics-data-api-client',
-    version='0.8.0',
+    version='0.9.0',
     packages=['analyticsclient', 'analyticsclient.constants'],
     url='https://github.com/edx/edx-analytics-data-api-client',
     description='Client used to access edX analytics data warehouse',


### PR DESCRIPTION
OpenCraft ticket: [OC-1823](https://tasks.opencraft.com/browse/OC-1823)

Description: This PR complements https://github.com/edx/edx-analytics-data-api/pull/131 and allows Insights to download reports such as the Problem Response Report.

Example usage:

```python
course = client.courses(course_id)
report_info = course.reports("problem_response")
```

Testing instructions:
* Test as part of https://github.com/edx/edx-analytics-dashboard/pull/538