### PR TITLE
EDUCATOR-464: Change course_summaries() to use POST instead of GET

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@ Dylan Rhodes <dylanr@stanford.edu>
 Dmitry Viskov <dmitry.viskov@webenterprise.ru>
 Tyler Hallada <thallada@edx.org>
 Braden MacDonald <braden@opencraft.com>
+Kyle McCormick <kylemccor@gmail.com>

--- a/analyticsclient/course_summaries.py
+++ b/analyticsclient/course_summaries.py
@@ -1,5 +1,3 @@
-import urllib
-
 import analyticsclient.constants.data_format as DF
 
 
@@ -27,15 +25,12 @@ class CourseSummaries(object):
             exclude: Array of fields to exclude from response. Default is to not exclude any fields.
             programs: If included in the query parameters, will include the programs array in the response.
         """
-        query_params = {}
-        for query_arg, data in zip(['course_ids', 'fields', 'exclude', 'programs'],
-                                   [course_ids, fields, exclude, programs]):
+        post_data = {}
+        for param_name, data in zip(['course_ids', 'fields', 'exclude', 'programs'],
+                                    [course_ids, fields, exclude, programs]):
             if data:
-                query_params[query_arg] = ','.join(data)
+                post_data[param_name] = data
 
         path = 'course_summaries/'
-        querystring = urllib.urlencode(query_params)
-        if querystring:
-            path += '?{0}'.format(querystring)
 
-        return self.client.get(path, data_format=data_format)
+        return self.client.post(path, post_data=post_data, data_format=data_format)

--- a/analyticsclient/tests/test_course_summaries.py
+++ b/analyticsclient/tests/test_course_summaries.py
@@ -9,6 +9,7 @@ class CourseSummariesTests(APIListTestCase, ClientTestCase):
 
     endpoint = 'course_summaries'
     id_field = 'course_ids'
+    uses_post_method = True
 
     @ddt.data(
         ['123'],


### PR DESCRIPTION
In the [Analytics API PR #173](https://github.com/edx/edx-analytics-data-api/pull/173), support for the POST method was added to the API's course_summaries/ endpoint, allowing a large number of `course_ids` to be passed as arguments in the request body. This PR takes advantage of that new functionality by adding a `post()` function to the `Client` class and updating the `CourseSummaries.course_summaries()` function to use said `post()` function.

JIRA Ticket: [EDUCATOR-464](https://openedx.atlassian.net/browse/EDUCATOR-464).

TODO:
- [x] Write tests
- [x] Get thumbs

@edx/educator-dahlia 
