### PR TITLE
feat(engagement-timeline): add engagement timeline client method

### DIFF
--- a/analyticsclient/client.py
+++ b/analyticsclient/client.py
@@ -7,6 +7,7 @@ from analyticsclient.constants import http_methods, data_formats
 from analyticsclient.course import Course
 from analyticsclient.course_totals import CourseTotals
 from analyticsclient.course_summaries import CourseSummaries
+from analyticsclient.engagement_timeline import EngagementTimeline
 from analyticsclient.exceptions import ClientError, InvalidRequestError, NotFoundError, TimeoutError
 from analyticsclient.module import Module
 from analyticsclient.programs import Programs
@@ -48,6 +49,7 @@ class Client(object):
         self.programs = lambda: Programs(self)
         self.courses = lambda course_id: Course(self, course_id)
         self.modules = lambda course_id, module_id: Module(self, course_id, module_id)
+        self.engagement_timeline = lambda username, course_id: EngagementTimeline(self, username, course_id)
 
     def get(self, *args, **kwargs):
         """

--- a/analyticsclient/engagement_timeline.py
+++ b/analyticsclient/engagement_timeline.py
@@ -1,0 +1,29 @@
+import urllib
+from analyticsclient.base import PostableCourseIDsEndpoint
+from analyticsclient.constants import data_formats
+
+
+class EngagementTimeline(PostableCourseIDsEndpoint):
+    """Engagement Timeline."""
+
+    def __init__(self, client, username, course_id):
+        """
+        Initialize the EngagementTimeline client.
+
+        Arguments:
+
+            client (analyticsclient.client.Client): The client to use to access remote resources.
+            username (str): String identifying the user (e.g. jbradley)
+            course_id (str): String identifying the course (e.g. edX/DemoX/Demo_Course)
+
+        """
+        super(EngagementTimeline, self).__init__(client)
+
+        self.username = unicode(username)
+        self.course_id = unicode(course_id)
+
+    def get(self):
+        """Get a particular learner's engagement timeline for a particular course."""
+        querystring = urllib.urlencode({'course_id': self.course_id})
+        path = 'engagement_timelines/{username}/?{querystring}'.format(username=self.username, querystring=querystring)
+        return self.client.get(path, data_format=data_formats.JSON)

--- a/analyticsclient/tests/test_engagement_timeline.py
+++ b/analyticsclient/tests/test_engagement_timeline.py
@@ -1,0 +1,46 @@
+import json
+
+import httpretty
+
+from analyticsclient.exceptions import NotFoundError
+from analyticsclient.tests import ClientTestCase
+
+
+class EngagementTimelineTests(ClientTestCase):
+
+    def setUp(self):
+        super(EngagementTimelineTests, self).setUp()
+        self.username = 'edx'
+        self.course_id = 'edX/DemoX/Demo_Course'
+        self.engagement_timeline = self.client.engagement_timeline(self.username, self.course_id)
+        httpretty.enable()
+
+    def tearDown(self):
+        super(EngagementTimelineTests, self).tearDown()
+        httpretty.disable()
+
+    def test_not_found(self):
+        not_a_valid_course_id = 'foobar'
+        uri = self.get_api_url('engagement_timelines/{username}/?course_id={course_id}'
+                               .format(username=self.username, course_id=not_a_valid_course_id))
+        httpretty.register_uri(httpretty.GET, uri, status=404)
+
+        engagement_timeline = self.client.engagement_timeline(self.username, not_a_valid_course_id)
+        self.assertRaises(NotFoundError, engagement_timeline.get)
+
+    def test_engagement_timeline(self):
+        body = {
+            "days": [
+                {
+                    "date": "date",
+                    "problems_attempted": 0,
+                    "problems_completed": 0,
+                    "discussion_contributions": 0,
+                    "videos_viewed": 3
+                }
+            ]
+        }
+        uri = self.get_api_url('engagement_timelines/{username}/?course_id={course_id}'
+                               .format(username=self.username, course_id=self.course_id))
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+        self.assertEqual(body, self.engagement_timeline.get())

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='edx-analytics-data-api-client',
-    version='0.13.0',
+    version='0.14.0',
     packages=['analyticsclient', 'analyticsclient.constants'],
     url='https://github.com/edx/edx-analytics-data-api-client',
     description='Client used to access edX analytics data warehouse',


### PR DESCRIPTION
Add method for [the engagement timeline endpoint](https://github.com/edx/edx-analytics-data-api/blob/f2ba8b27711c4f6c0f5d21809a00452141a77036/analytics_data_api/v0/views/learners.py#L301-L355).

We (Learner-Growth) are planning on using this endpoint as part of the Learner Analytics dashboard test we're running - in part, we are using this endpoint to track the number of days in a row a learner has performed an action.

TODO:

- [x] Do I need to update the version in `setup.py`?

cc: @dsjen @thallada 