### PR TITLE
INCR-20: Add tox.ini

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 install:
 - pip install coveralls
 - pip install -r requirements.txt
-script: make test quality
+script: tox
 after_success:
 - coveralls
 - bash ./scripts/build-stats-to-datadog.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ pylint==1.6.4
 pep257==0.7.0
 mock==2.0.0
 testfixtures==4.13.3
+tox-travis==0.11
+tox==3.7.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py36
+
+[testenv]
+deps = -r{toxinidir}/requirements.txt
+commands = make test quality
+whitelist_externals = make


### PR DESCRIPTION
Create an appropriate tox.ini file for running tests in Python 2.7 and 3.6