### PR TITLE
Add py36 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
-python: '2.7'
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
+  allow_failures:
+    - env: TOXENV=py36
 cache: pip
 sudo: false
 install:


### PR DESCRIPTION
Get python 3.6 running in CI. It will fail for now, but will help us as we start adding more INCR tickets to this repo.